### PR TITLE
Added Filename to Component class

### DIFF
--- a/ComponentRepository/RepositoryComponent/Component.cs
+++ b/ComponentRepository/RepositoryComponent/Component.cs
@@ -4,19 +4,16 @@ using System.Data.Linq;
 
 namespace RepositoryComponent
 {
-    public class ComponentInformation
+
+    public class Component
     {
         //Properties
         public int Id { get; set; }
         public string Title { get; set; }
         public string ShortDescription { get; set; }
         public string LongDescription { get; set; }
+        public string FileName { get; set; }
         public string Metadata { get; set; }
-    }
-
-    public class Component : ComponentInformation
-    {
-        //Properties
         public byte[] Content { get; set; }
     }
 

--- a/ComponentRepository/RepositoryComponent/IWeb.cs
+++ b/ComponentRepository/RepositoryComponent/IWeb.cs
@@ -7,6 +7,6 @@ namespace RepositoryComponent
     public interface IWeb
     {
         List<Component> GetComponents();
-        byte[] DownloadComponent(int id);
+        (byte[] content, string fileName) DownloadComponent(int id);
     }
 }

--- a/ComponentRepository/RepositoryComponent/RepositoryComponent.csproj
+++ b/ComponentRepository/RepositoryComponent/RepositoryComponent.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Linq" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ComponentRepository/RepositoryComponent/RepositoryService.cs
+++ b/ComponentRepository/RepositoryComponent/RepositoryService.cs
@@ -13,11 +13,12 @@ namespace RepositoryComponent
             throw new NotImplementedException();
         }
 
-        public byte[] DownloadComponent(int id)
+        public (byte[] content, string fileName) DownloadComponent(int id)
         {
             using (var db = new ComponentContext())
             {
-                return db.Components.Find(id).Content;
+                var component = db.Components.Find(id);
+                return (component.Content, component.FileName);
             }
         }
 

--- a/ComponentRepository/RepositoryComponent/packages.config
+++ b/ComponentRepository/RepositoryComponent/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/ComponentRepository/UnitTestRepositoryComponent/UnitTest1.cs
+++ b/ComponentRepository/UnitTestRepositoryComponent/UnitTest1.cs
@@ -21,6 +21,7 @@ namespace UnitTestRepositoryComponent
                     Title = "TestComponent",
                     ShortDescription = "This is a test component",
                     LongDescription = "this component test that the database connection works.",
+                    FileName = "atl.dll",
                     Metadata = @"{
     'classes': [
     ],

--- a/ComponentRepository/WebComponent/Controllers/HomeController.cs
+++ b/ComponentRepository/WebComponent/Controllers/HomeController.cs
@@ -20,7 +20,8 @@ namespace WebComponent.Controllers
         {
             IWeb repo = new RepositoryService();
             // application/x-msdownload
-            return File(repo.DownloadComponent(id), "application/octet-stream", "test.dll");
+            var (content, fileName) = repo.DownloadComponent(id);
+            return File(content, "application/octet-stream", fileName);
         }
     }
 }

--- a/ComponentRepository/WebComponent/WebComponent.csproj
+++ b/ComponentRepository/WebComponent/WebComponent.csproj
@@ -55,6 +55,9 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/ComponentRepository/WebComponent/packages.config
+++ b/ComponentRepository/WebComponent/packages.config
@@ -23,5 +23,6 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
When downloading a component we need to supply a filename in addition to the byte array.
Therefore I propose that we add a filename property to the component class

```diff
public class Component {
...
+    public string FileName { get; set; }
...
}
```

Since the filename is required when downloading a component, I propose that we add it as a tuple on the download method.

```diff
public interface IWeb {
    List<Component> GetComponents();
-   byte[] DownloadComponent(int id);
+   (byte[] content, string fileName) DownloadComponent(int id);
}
```

As a result of this pull request we need to update the class diagram and update the component class, the iWeb interface and RepositoryService. We also need to update ER diagram.